### PR TITLE
Balance Board: zero point calibration

### DIFF
--- a/WiimoteCS/WiimoteLib/DataTypes.cs
+++ b/WiimoteCS/WiimoteLib/DataTypes.cs
@@ -538,6 +538,11 @@ namespace WiimoteLib
 		[DataMember]
 		public BalanceBoardSensorsF SensorValuesLb;
 		/// <summary>
+		/// Zero Point / tare values 
+		/// </summary>
+		[DataMember]
+		public ZeroPoint ZeroPoint;
+		/// <summary>
 		/// Total kilograms on the Balance Board
 		/// </summary>
 		[DataMember]
@@ -634,6 +639,30 @@ namespace WiimoteLib
 		/// </summary>
 		[DataMember]
 		public float BottomLeft;
+	}
+
+	/// /// <summary>
+	/// Zero Point / tare values
+	/// </summary>
+	[Serializable]
+	[DataContract]
+	public struct ZeroPoint
+    {
+		/// <summary>
+		/// Kilograms per sensor
+		/// </summary>
+		[DataMember]
+		public BalanceBoardSensorsF SensorValuesKg;
+		/// <summary>
+		/// Has Zero Point been set?
+		/// </summary>
+		[DataMember]
+		public Boolean IsSet;
+		/// <summary>
+		/// Set the zero point
+		/// </summary>
+		[DataMember]
+		public Boolean Reset;
 	}
 
 	/// <summary>

--- a/WiimoteCS/WiimoteLib/Wiimote.cs
+++ b/WiimoteCS/WiimoteLib/Wiimote.cs
@@ -862,6 +862,25 @@ namespace WiimoteLib
 					mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft = GetBalanceBoardSensorValue(mWiimoteState.BalanceBoardState.SensorValuesRaw.BottomLeft, mWiimoteState.BalanceBoardState.CalibrationInfo.Kg0.BottomLeft, mWiimoteState.BalanceBoardState.CalibrationInfo.Kg17.BottomLeft, mWiimoteState.BalanceBoardState.CalibrationInfo.Kg34.BottomLeft);
 					mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight = GetBalanceBoardSensorValue(mWiimoteState.BalanceBoardState.SensorValuesRaw.BottomRight, mWiimoteState.BalanceBoardState.CalibrationInfo.Kg0.BottomRight, mWiimoteState.BalanceBoardState.CalibrationInfo.Kg17.BottomRight, mWiimoteState.BalanceBoardState.CalibrationInfo.Kg34.BottomRight);
 
+					if (mWiimoteState.BalanceBoardState.ZeroPoint.Reset)
+                    {
+						mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.TopLeft = mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft;
+						mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.TopRight = mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight;
+						mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.BottomLeft = mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft;
+						mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.BottomRight = mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight;
+						mWiimoteState.BalanceBoardState.ZeroPoint.IsSet = true;
+						mWiimoteState.BalanceBoardState.ZeroPoint.Reset = false;
+						// todo: average over 2 seconds of readings, if values are not stable, reset failed.
+					}
+
+					if (mWiimoteState.BalanceBoardState.ZeroPoint.IsSet)
+                    {
+						mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft -= mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.TopLeft;
+						mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight -= mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.TopRight;
+						mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft -= mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.BottomLeft;
+						mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight -= mWiimoteState.BalanceBoardState.ZeroPoint.SensorValuesKg.BottomRight;
+					}
+
 					mWiimoteState.BalanceBoardState.SensorValuesLb.TopLeft = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft * KG2LB);
 					mWiimoteState.BalanceBoardState.SensorValuesLb.TopRight = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight * KG2LB);
 					mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft = (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft * KG2LB);

--- a/WiimoteCS/WiimoteLib/Wiimote.cs
+++ b/WiimoteCS/WiimoteLib/Wiimote.cs
@@ -867,8 +867,8 @@ namespace WiimoteLib
 					mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft = (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft * KG2LB);
 					mWiimoteState.BalanceBoardState.SensorValuesLb.BottomRight = (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight * KG2LB);
 
-					mWiimoteState.BalanceBoardState.WeightKg = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight) / 4.0f;
-					mWiimoteState.BalanceBoardState.WeightLb = (mWiimoteState.BalanceBoardState.SensorValuesLb.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.TopRight + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomRight) / 4.0f;
+					mWiimoteState.BalanceBoardState.WeightKg = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight);
+					mWiimoteState.BalanceBoardState.WeightLb = (mWiimoteState.BalanceBoardState.SensorValuesLb.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.TopRight + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomRight);
 
 					float Kx = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft) / (mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight);
 					float Ky = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight) / (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight);
@@ -885,9 +885,9 @@ namespace WiimoteLib
 				return 0;
 
 			if(sensor < mid)
-				return 68.0f * ((float)(sensor - min) / (mid - min));
+				return 17.0f * ((float)(sensor - min) / (mid - min));
 			else
-				return 68.0f * ((float)(sensor - mid) / (max - mid)) + 68.0f;
+				return 17.0f * ((float)(sensor - mid) / (max - mid)) + 17.0f;
 		}
 
 

--- a/WiimoteCS/WiimoteTest/WiimoteInfo.Designer.cs
+++ b/WiimoteCS/WiimoteTest/WiimoteInfo.Designer.cs
@@ -28,91 +28,92 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.groupBox8 = new System.Windows.Forms.GroupBox();
-			this.clbButtons = new System.Windows.Forms.CheckedListBox();
-			this.lblTriggerR = new System.Windows.Forms.Label();
-			this.lblTriggerL = new System.Windows.Forms.Label();
-			this.lblIR3 = new System.Windows.Forms.Label();
-			this.lblIR4 = new System.Windows.Forms.Label();
-			this.lblCCJoy2 = new System.Windows.Forms.Label();
-			this.lblCCJoy1 = new System.Windows.Forms.Label();
-			this.groupBox5 = new System.Windows.Forms.GroupBox();
-			this.lblIR3Raw = new System.Windows.Forms.Label();
-			this.lblIR1Raw = new System.Windows.Forms.Label();
-			this.lblIR4Raw = new System.Windows.Forms.Label();
-			this.lblIR2Raw = new System.Windows.Forms.Label();
-			this.lblIR1 = new System.Windows.Forms.Label();
-			this.lblIR2 = new System.Windows.Forms.Label();
-			this.chkFound3 = new System.Windows.Forms.CheckBox();
-			this.chkFound4 = new System.Windows.Forms.CheckBox();
-			this.chkFound1 = new System.Windows.Forms.CheckBox();
-			this.chkFound2 = new System.Windows.Forms.CheckBox();
-			this.pbIR = new System.Windows.Forms.PictureBox();
-			this.lblGuitarWhammy = new System.Windows.Forms.Label();
-			this.groupBox7 = new System.Windows.Forms.GroupBox();
-			this.clbTouchbar = new System.Windows.Forms.CheckedListBox();
-			this.lblGuitarType = new System.Windows.Forms.Label();
-			this.lblGuitarJoy = new System.Windows.Forms.Label();
-			this.clbGuitarButtons = new System.Windows.Forms.CheckedListBox();
-			this.groupBox6 = new System.Windows.Forms.GroupBox();
-			this.clbCCButtons = new System.Windows.Forms.CheckedListBox();
-			this.groupBox4 = new System.Windows.Forms.GroupBox();
-			this.pbBattery = new System.Windows.Forms.ProgressBar();
-			this.lblBattery = new System.Windows.Forms.Label();
-			this.groupBox3 = new System.Windows.Forms.GroupBox();
-			this.chkLED2 = new System.Windows.Forms.CheckBox();
-			this.chkLED4 = new System.Windows.Forms.CheckBox();
-			this.chkLED3 = new System.Windows.Forms.CheckBox();
-			this.chkLED1 = new System.Windows.Forms.CheckBox();
-			this.chkRumble = new System.Windows.Forms.CheckBox();
-			this.chkZ = new System.Windows.Forms.CheckBox();
-			this.chkC = new System.Windows.Forms.CheckBox();
-			this.lblChuk = new System.Windows.Forms.Label();
-			this.groupBox2 = new System.Windows.Forms.GroupBox();
-			this.lblChukJoy = new System.Windows.Forms.Label();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.lblAccel = new System.Windows.Forms.Label();
-			this.chkExtension = new System.Windows.Forms.CheckBox();
-			this.groupBox9 = new System.Windows.Forms.GroupBox();
-			this.lblCOG = new System.Windows.Forms.Label();
-			this.chkLbs = new System.Windows.Forms.CheckBox();
-			this.lblBBBR = new System.Windows.Forms.Label();
-			this.lblBBTR = new System.Windows.Forms.Label();
-			this.lblBBBL = new System.Windows.Forms.Label();
-			this.lblBBTotal = new System.Windows.Forms.Label();
-			this.lblBBTL = new System.Windows.Forms.Label();
-			this.lblDevicePath = new System.Windows.Forms.Label();
-			this.groupBox10 = new System.Windows.Forms.GroupBox();
-			this.lbDrumVelocity = new System.Windows.Forms.ListBox();
-			this.lblDrumJoy = new System.Windows.Forms.Label();
-			this.clbDrums = new System.Windows.Forms.CheckedListBox();
-			this.groupBox8.SuspendLayout();
-			this.groupBox5.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pbIR)).BeginInit();
-			this.groupBox7.SuspendLayout();
-			this.groupBox6.SuspendLayout();
-			this.groupBox4.SuspendLayout();
-			this.groupBox3.SuspendLayout();
-			this.groupBox2.SuspendLayout();
-			this.groupBox1.SuspendLayout();
-			this.groupBox9.SuspendLayout();
-			this.groupBox10.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// groupBox8
-			// 
-			this.groupBox8.Controls.Add(this.clbButtons);
-			this.groupBox8.Location = new System.Drawing.Point(0, 0);
-			this.groupBox8.Name = "groupBox8";
-			this.groupBox8.Size = new System.Drawing.Size(72, 220);
-			this.groupBox8.TabIndex = 37;
-			this.groupBox8.TabStop = false;
-			this.groupBox8.Text = "Wiimote";
-			// 
-			// clbButtons
-			// 
-			this.clbButtons.FormattingEnabled = true;
-			this.clbButtons.Items.AddRange(new object[] {
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.clbButtons = new System.Windows.Forms.CheckedListBox();
+            this.lblTriggerR = new System.Windows.Forms.Label();
+            this.lblTriggerL = new System.Windows.Forms.Label();
+            this.lblIR3 = new System.Windows.Forms.Label();
+            this.lblIR4 = new System.Windows.Forms.Label();
+            this.lblCCJoy2 = new System.Windows.Forms.Label();
+            this.lblCCJoy1 = new System.Windows.Forms.Label();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.lblIR3Raw = new System.Windows.Forms.Label();
+            this.lblIR1Raw = new System.Windows.Forms.Label();
+            this.lblIR4Raw = new System.Windows.Forms.Label();
+            this.lblIR2Raw = new System.Windows.Forms.Label();
+            this.lblIR1 = new System.Windows.Forms.Label();
+            this.lblIR2 = new System.Windows.Forms.Label();
+            this.chkFound3 = new System.Windows.Forms.CheckBox();
+            this.chkFound4 = new System.Windows.Forms.CheckBox();
+            this.chkFound1 = new System.Windows.Forms.CheckBox();
+            this.chkFound2 = new System.Windows.Forms.CheckBox();
+            this.pbIR = new System.Windows.Forms.PictureBox();
+            this.lblGuitarWhammy = new System.Windows.Forms.Label();
+            this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.clbTouchbar = new System.Windows.Forms.CheckedListBox();
+            this.lblGuitarType = new System.Windows.Forms.Label();
+            this.lblGuitarJoy = new System.Windows.Forms.Label();
+            this.clbGuitarButtons = new System.Windows.Forms.CheckedListBox();
+            this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.clbCCButtons = new System.Windows.Forms.CheckedListBox();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.pbBattery = new System.Windows.Forms.ProgressBar();
+            this.lblBattery = new System.Windows.Forms.Label();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.chkLED2 = new System.Windows.Forms.CheckBox();
+            this.chkLED4 = new System.Windows.Forms.CheckBox();
+            this.chkLED3 = new System.Windows.Forms.CheckBox();
+            this.chkLED1 = new System.Windows.Forms.CheckBox();
+            this.chkRumble = new System.Windows.Forms.CheckBox();
+            this.chkZ = new System.Windows.Forms.CheckBox();
+            this.chkC = new System.Windows.Forms.CheckBox();
+            this.lblChuk = new System.Windows.Forms.Label();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.lblChukJoy = new System.Windows.Forms.Label();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.lblAccel = new System.Windows.Forms.Label();
+            this.chkExtension = new System.Windows.Forms.CheckBox();
+            this.groupBox9 = new System.Windows.Forms.GroupBox();
+            this.SetZeroPoint = new System.Windows.Forms.Button();
+            this.lblCOG = new System.Windows.Forms.Label();
+            this.chkLbs = new System.Windows.Forms.CheckBox();
+            this.lblBBBR = new System.Windows.Forms.Label();
+            this.lblBBTR = new System.Windows.Forms.Label();
+            this.lblBBBL = new System.Windows.Forms.Label();
+            this.lblBBTotal = new System.Windows.Forms.Label();
+            this.lblBBTL = new System.Windows.Forms.Label();
+            this.lblDevicePath = new System.Windows.Forms.Label();
+            this.groupBox10 = new System.Windows.Forms.GroupBox();
+            this.lbDrumVelocity = new System.Windows.Forms.ListBox();
+            this.lblDrumJoy = new System.Windows.Forms.Label();
+            this.clbDrums = new System.Windows.Forms.CheckedListBox();
+            this.groupBox8.SuspendLayout();
+            this.groupBox5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pbIR)).BeginInit();
+            this.groupBox7.SuspendLayout();
+            this.groupBox6.SuspendLayout();
+            this.groupBox4.SuspendLayout();
+            this.groupBox3.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.groupBox9.SuspendLayout();
+            this.groupBox10.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.Controls.Add(this.clbButtons);
+            this.groupBox8.Location = new System.Drawing.Point(0, 0);
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.Size = new System.Drawing.Size(72, 220);
+            this.groupBox8.TabIndex = 37;
+            this.groupBox8.TabStop = false;
+            this.groupBox8.Text = "Wiimote";
+            // 
+            // clbButtons
+            // 
+            this.clbButtons.FormattingEnabled = true;
+            this.clbButtons.Items.AddRange(new object[] {
             "A",
             "B",
             "-",
@@ -124,244 +125,244 @@
             "Down",
             "Left",
             "Right"});
-			this.clbButtons.Location = new System.Drawing.Point(8, 16);
-			this.clbButtons.Name = "clbButtons";
-			this.clbButtons.Size = new System.Drawing.Size(56, 184);
-			this.clbButtons.TabIndex = 1;
-			// 
-			// lblTriggerR
-			// 
-			this.lblTriggerR.AutoSize = true;
-			this.lblTriggerR.Location = new System.Drawing.Point(76, 104);
-			this.lblTriggerR.Name = "lblTriggerR";
-			this.lblTriggerR.Size = new System.Drawing.Size(51, 13);
-			this.lblTriggerR.TabIndex = 25;
-			this.lblTriggerR.Text = "Trigger R";
-			// 
-			// lblTriggerL
-			// 
-			this.lblTriggerL.AutoSize = true;
-			this.lblTriggerL.Location = new System.Drawing.Point(76, 88);
-			this.lblTriggerL.Name = "lblTriggerL";
-			this.lblTriggerL.Size = new System.Drawing.Size(49, 13);
-			this.lblTriggerL.TabIndex = 24;
-			this.lblTriggerL.Text = "Trigger L";
-			// 
-			// lblIR3
-			// 
-			this.lblIR3.AutoSize = true;
-			this.lblIR3.Location = new System.Drawing.Point(8, 48);
-			this.lblIR3.Name = "lblIR3";
-			this.lblIR3.Size = new System.Drawing.Size(24, 13);
-			this.lblIR3.TabIndex = 7;
-			this.lblIR3.Text = "IR3";
-			// 
-			// lblIR4
-			// 
-			this.lblIR4.AutoSize = true;
-			this.lblIR4.Location = new System.Drawing.Point(8, 64);
-			this.lblIR4.Name = "lblIR4";
-			this.lblIR4.Size = new System.Drawing.Size(24, 13);
-			this.lblIR4.TabIndex = 7;
-			this.lblIR4.Text = "IR4";
-			// 
-			// lblCCJoy2
-			// 
-			this.lblCCJoy2.Location = new System.Drawing.Point(76, 52);
-			this.lblCCJoy2.Name = "lblCCJoy2";
-			this.lblCCJoy2.Size = new System.Drawing.Size(108, 32);
-			this.lblCCJoy2.TabIndex = 24;
-			this.lblCCJoy2.Text = "Right Joystick";
-			// 
-			// lblCCJoy1
-			// 
-			this.lblCCJoy1.Location = new System.Drawing.Point(76, 16);
-			this.lblCCJoy1.Name = "lblCCJoy1";
-			this.lblCCJoy1.Size = new System.Drawing.Size(108, 32);
-			this.lblCCJoy1.TabIndex = 24;
-			this.lblCCJoy1.Text = "Left Joystick";
-			// 
-			// groupBox5
-			// 
-			this.groupBox5.Controls.Add(this.lblIR3Raw);
-			this.groupBox5.Controls.Add(this.lblIR1Raw);
-			this.groupBox5.Controls.Add(this.lblIR4Raw);
-			this.groupBox5.Controls.Add(this.lblIR2Raw);
-			this.groupBox5.Controls.Add(this.lblIR3);
-			this.groupBox5.Controls.Add(this.lblIR1);
-			this.groupBox5.Controls.Add(this.lblIR4);
-			this.groupBox5.Controls.Add(this.lblIR2);
-			this.groupBox5.Controls.Add(this.chkFound3);
-			this.groupBox5.Controls.Add(this.chkFound4);
-			this.groupBox5.Controls.Add(this.chkFound1);
-			this.groupBox5.Controls.Add(this.chkFound2);
-			this.groupBox5.Location = new System.Drawing.Point(184, 0);
-			this.groupBox5.Name = "groupBox5";
-			this.groupBox5.Size = new System.Drawing.Size(176, 188);
-			this.groupBox5.TabIndex = 34;
-			this.groupBox5.TabStop = false;
-			this.groupBox5.Text = "IR";
-			// 
-			// lblIR3Raw
-			// 
-			this.lblIR3Raw.AutoSize = true;
-			this.lblIR3Raw.Location = new System.Drawing.Point(8, 112);
-			this.lblIR3Raw.Name = "lblIR3Raw";
-			this.lblIR3Raw.Size = new System.Drawing.Size(46, 13);
-			this.lblIR3Raw.TabIndex = 10;
-			this.lblIR3Raw.Text = "IR3Raw";
-			// 
-			// lblIR1Raw
-			// 
-			this.lblIR1Raw.AutoSize = true;
-			this.lblIR1Raw.Location = new System.Drawing.Point(8, 80);
-			this.lblIR1Raw.Name = "lblIR1Raw";
-			this.lblIR1Raw.Size = new System.Drawing.Size(46, 13);
-			this.lblIR1Raw.TabIndex = 10;
-			this.lblIR1Raw.Text = "IR1Raw";
-			// 
-			// lblIR4Raw
-			// 
-			this.lblIR4Raw.AutoSize = true;
-			this.lblIR4Raw.Location = new System.Drawing.Point(8, 128);
-			this.lblIR4Raw.Name = "lblIR4Raw";
-			this.lblIR4Raw.Size = new System.Drawing.Size(46, 13);
-			this.lblIR4Raw.TabIndex = 9;
-			this.lblIR4Raw.Text = "IR4Raw";
-			// 
-			// lblIR2Raw
-			// 
-			this.lblIR2Raw.AutoSize = true;
-			this.lblIR2Raw.Location = new System.Drawing.Point(8, 96);
-			this.lblIR2Raw.Name = "lblIR2Raw";
-			this.lblIR2Raw.Size = new System.Drawing.Size(46, 13);
-			this.lblIR2Raw.TabIndex = 9;
-			this.lblIR2Raw.Text = "IR2Raw";
-			// 
-			// lblIR1
-			// 
-			this.lblIR1.AutoSize = true;
-			this.lblIR1.Location = new System.Drawing.Point(8, 16);
-			this.lblIR1.Name = "lblIR1";
-			this.lblIR1.Size = new System.Drawing.Size(24, 13);
-			this.lblIR1.TabIndex = 7;
-			this.lblIR1.Text = "IR1";
-			// 
-			// lblIR2
-			// 
-			this.lblIR2.AutoSize = true;
-			this.lblIR2.Location = new System.Drawing.Point(8, 32);
-			this.lblIR2.Name = "lblIR2";
-			this.lblIR2.Size = new System.Drawing.Size(24, 13);
-			this.lblIR2.TabIndex = 7;
-			this.lblIR2.Text = "IR2";
-			// 
-			// chkFound3
-			// 
-			this.chkFound3.AutoSize = true;
-			this.chkFound3.Location = new System.Drawing.Point(60, 148);
-			this.chkFound3.Name = "chkFound3";
-			this.chkFound3.Size = new System.Drawing.Size(46, 17);
-			this.chkFound3.TabIndex = 8;
-			this.chkFound3.Text = "IR 3";
-			this.chkFound3.UseVisualStyleBackColor = true;
-			// 
-			// chkFound4
-			// 
-			this.chkFound4.AutoSize = true;
-			this.chkFound4.Location = new System.Drawing.Point(60, 164);
-			this.chkFound4.Name = "chkFound4";
-			this.chkFound4.Size = new System.Drawing.Size(46, 17);
-			this.chkFound4.TabIndex = 8;
-			this.chkFound4.Text = "IR 4";
-			this.chkFound4.UseVisualStyleBackColor = true;
-			// 
-			// chkFound1
-			// 
-			this.chkFound1.AutoSize = true;
-			this.chkFound1.Location = new System.Drawing.Point(8, 148);
-			this.chkFound1.Name = "chkFound1";
-			this.chkFound1.Size = new System.Drawing.Size(46, 17);
-			this.chkFound1.TabIndex = 8;
-			this.chkFound1.Text = "IR 1";
-			this.chkFound1.UseVisualStyleBackColor = true;
-			// 
-			// chkFound2
-			// 
-			this.chkFound2.AutoSize = true;
-			this.chkFound2.Location = new System.Drawing.Point(8, 164);
-			this.chkFound2.Name = "chkFound2";
-			this.chkFound2.Size = new System.Drawing.Size(46, 17);
-			this.chkFound2.TabIndex = 8;
-			this.chkFound2.Text = "IR 2";
-			this.chkFound2.UseVisualStyleBackColor = true;
-			// 
-			// pbIR
-			// 
-			this.pbIR.Location = new System.Drawing.Point(4, 248);
-			this.pbIR.Name = "pbIR";
-			this.pbIR.Size = new System.Drawing.Size(256, 192);
-			this.pbIR.TabIndex = 28;
-			this.pbIR.TabStop = false;
-			// 
-			// lblGuitarWhammy
-			// 
-			this.lblGuitarWhammy.AutoSize = true;
-			this.lblGuitarWhammy.Location = new System.Drawing.Point(92, 140);
-			this.lblGuitarWhammy.Name = "lblGuitarWhammy";
-			this.lblGuitarWhammy.Size = new System.Drawing.Size(51, 13);
-			this.lblGuitarWhammy.TabIndex = 24;
-			this.lblGuitarWhammy.Text = "Whammy";
-			// 
-			// groupBox7
-			// 
-			this.groupBox7.Controls.Add(this.clbTouchbar);
-			this.groupBox7.Controls.Add(this.lblGuitarType);
-			this.groupBox7.Controls.Add(this.lblGuitarWhammy);
-			this.groupBox7.Controls.Add(this.lblGuitarJoy);
-			this.groupBox7.Controls.Add(this.clbGuitarButtons);
-			this.groupBox7.Location = new System.Drawing.Point(364, 272);
-			this.groupBox7.Name = "groupBox7";
-			this.groupBox7.Size = new System.Drawing.Size(188, 176);
-			this.groupBox7.TabIndex = 36;
-			this.groupBox7.TabStop = false;
-			this.groupBox7.Text = "Guitar";
-			// 
-			// clbTouchbar
-			// 
-			this.clbTouchbar.FormattingEnabled = true;
-			this.clbTouchbar.Items.AddRange(new object[] {
+            this.clbButtons.Location = new System.Drawing.Point(8, 16);
+            this.clbButtons.Name = "clbButtons";
+            this.clbButtons.Size = new System.Drawing.Size(56, 184);
+            this.clbButtons.TabIndex = 1;
+            // 
+            // lblTriggerR
+            // 
+            this.lblTriggerR.AutoSize = true;
+            this.lblTriggerR.Location = new System.Drawing.Point(76, 104);
+            this.lblTriggerR.Name = "lblTriggerR";
+            this.lblTriggerR.Size = new System.Drawing.Size(51, 13);
+            this.lblTriggerR.TabIndex = 25;
+            this.lblTriggerR.Text = "Trigger R";
+            // 
+            // lblTriggerL
+            // 
+            this.lblTriggerL.AutoSize = true;
+            this.lblTriggerL.Location = new System.Drawing.Point(76, 88);
+            this.lblTriggerL.Name = "lblTriggerL";
+            this.lblTriggerL.Size = new System.Drawing.Size(49, 13);
+            this.lblTriggerL.TabIndex = 24;
+            this.lblTriggerL.Text = "Trigger L";
+            // 
+            // lblIR3
+            // 
+            this.lblIR3.AutoSize = true;
+            this.lblIR3.Location = new System.Drawing.Point(8, 48);
+            this.lblIR3.Name = "lblIR3";
+            this.lblIR3.Size = new System.Drawing.Size(24, 13);
+            this.lblIR3.TabIndex = 7;
+            this.lblIR3.Text = "IR3";
+            // 
+            // lblIR4
+            // 
+            this.lblIR4.AutoSize = true;
+            this.lblIR4.Location = new System.Drawing.Point(8, 64);
+            this.lblIR4.Name = "lblIR4";
+            this.lblIR4.Size = new System.Drawing.Size(24, 13);
+            this.lblIR4.TabIndex = 7;
+            this.lblIR4.Text = "IR4";
+            // 
+            // lblCCJoy2
+            // 
+            this.lblCCJoy2.Location = new System.Drawing.Point(76, 52);
+            this.lblCCJoy2.Name = "lblCCJoy2";
+            this.lblCCJoy2.Size = new System.Drawing.Size(108, 32);
+            this.lblCCJoy2.TabIndex = 24;
+            this.lblCCJoy2.Text = "Right Joystick";
+            // 
+            // lblCCJoy1
+            // 
+            this.lblCCJoy1.Location = new System.Drawing.Point(76, 16);
+            this.lblCCJoy1.Name = "lblCCJoy1";
+            this.lblCCJoy1.Size = new System.Drawing.Size(108, 32);
+            this.lblCCJoy1.TabIndex = 24;
+            this.lblCCJoy1.Text = "Left Joystick";
+            // 
+            // groupBox5
+            // 
+            this.groupBox5.Controls.Add(this.lblIR3Raw);
+            this.groupBox5.Controls.Add(this.lblIR1Raw);
+            this.groupBox5.Controls.Add(this.lblIR4Raw);
+            this.groupBox5.Controls.Add(this.lblIR2Raw);
+            this.groupBox5.Controls.Add(this.lblIR3);
+            this.groupBox5.Controls.Add(this.lblIR1);
+            this.groupBox5.Controls.Add(this.lblIR4);
+            this.groupBox5.Controls.Add(this.lblIR2);
+            this.groupBox5.Controls.Add(this.chkFound3);
+            this.groupBox5.Controls.Add(this.chkFound4);
+            this.groupBox5.Controls.Add(this.chkFound1);
+            this.groupBox5.Controls.Add(this.chkFound2);
+            this.groupBox5.Location = new System.Drawing.Point(184, 0);
+            this.groupBox5.Name = "groupBox5";
+            this.groupBox5.Size = new System.Drawing.Size(176, 188);
+            this.groupBox5.TabIndex = 34;
+            this.groupBox5.TabStop = false;
+            this.groupBox5.Text = "IR";
+            // 
+            // lblIR3Raw
+            // 
+            this.lblIR3Raw.AutoSize = true;
+            this.lblIR3Raw.Location = new System.Drawing.Point(8, 112);
+            this.lblIR3Raw.Name = "lblIR3Raw";
+            this.lblIR3Raw.Size = new System.Drawing.Size(46, 13);
+            this.lblIR3Raw.TabIndex = 10;
+            this.lblIR3Raw.Text = "IR3Raw";
+            // 
+            // lblIR1Raw
+            // 
+            this.lblIR1Raw.AutoSize = true;
+            this.lblIR1Raw.Location = new System.Drawing.Point(8, 80);
+            this.lblIR1Raw.Name = "lblIR1Raw";
+            this.lblIR1Raw.Size = new System.Drawing.Size(46, 13);
+            this.lblIR1Raw.TabIndex = 10;
+            this.lblIR1Raw.Text = "IR1Raw";
+            // 
+            // lblIR4Raw
+            // 
+            this.lblIR4Raw.AutoSize = true;
+            this.lblIR4Raw.Location = new System.Drawing.Point(8, 128);
+            this.lblIR4Raw.Name = "lblIR4Raw";
+            this.lblIR4Raw.Size = new System.Drawing.Size(46, 13);
+            this.lblIR4Raw.TabIndex = 9;
+            this.lblIR4Raw.Text = "IR4Raw";
+            // 
+            // lblIR2Raw
+            // 
+            this.lblIR2Raw.AutoSize = true;
+            this.lblIR2Raw.Location = new System.Drawing.Point(8, 96);
+            this.lblIR2Raw.Name = "lblIR2Raw";
+            this.lblIR2Raw.Size = new System.Drawing.Size(46, 13);
+            this.lblIR2Raw.TabIndex = 9;
+            this.lblIR2Raw.Text = "IR2Raw";
+            // 
+            // lblIR1
+            // 
+            this.lblIR1.AutoSize = true;
+            this.lblIR1.Location = new System.Drawing.Point(8, 16);
+            this.lblIR1.Name = "lblIR1";
+            this.lblIR1.Size = new System.Drawing.Size(24, 13);
+            this.lblIR1.TabIndex = 7;
+            this.lblIR1.Text = "IR1";
+            // 
+            // lblIR2
+            // 
+            this.lblIR2.AutoSize = true;
+            this.lblIR2.Location = new System.Drawing.Point(8, 32);
+            this.lblIR2.Name = "lblIR2";
+            this.lblIR2.Size = new System.Drawing.Size(24, 13);
+            this.lblIR2.TabIndex = 7;
+            this.lblIR2.Text = "IR2";
+            // 
+            // chkFound3
+            // 
+            this.chkFound3.AutoSize = true;
+            this.chkFound3.Location = new System.Drawing.Point(60, 148);
+            this.chkFound3.Name = "chkFound3";
+            this.chkFound3.Size = new System.Drawing.Size(46, 17);
+            this.chkFound3.TabIndex = 8;
+            this.chkFound3.Text = "IR 3";
+            this.chkFound3.UseVisualStyleBackColor = true;
+            // 
+            // chkFound4
+            // 
+            this.chkFound4.AutoSize = true;
+            this.chkFound4.Location = new System.Drawing.Point(60, 164);
+            this.chkFound4.Name = "chkFound4";
+            this.chkFound4.Size = new System.Drawing.Size(46, 17);
+            this.chkFound4.TabIndex = 8;
+            this.chkFound4.Text = "IR 4";
+            this.chkFound4.UseVisualStyleBackColor = true;
+            // 
+            // chkFound1
+            // 
+            this.chkFound1.AutoSize = true;
+            this.chkFound1.Location = new System.Drawing.Point(8, 148);
+            this.chkFound1.Name = "chkFound1";
+            this.chkFound1.Size = new System.Drawing.Size(46, 17);
+            this.chkFound1.TabIndex = 8;
+            this.chkFound1.Text = "IR 1";
+            this.chkFound1.UseVisualStyleBackColor = true;
+            // 
+            // chkFound2
+            // 
+            this.chkFound2.AutoSize = true;
+            this.chkFound2.Location = new System.Drawing.Point(8, 164);
+            this.chkFound2.Name = "chkFound2";
+            this.chkFound2.Size = new System.Drawing.Size(46, 17);
+            this.chkFound2.TabIndex = 8;
+            this.chkFound2.Text = "IR 2";
+            this.chkFound2.UseVisualStyleBackColor = true;
+            // 
+            // pbIR
+            // 
+            this.pbIR.Location = new System.Drawing.Point(4, 248);
+            this.pbIR.Name = "pbIR";
+            this.pbIR.Size = new System.Drawing.Size(256, 192);
+            this.pbIR.TabIndex = 28;
+            this.pbIR.TabStop = false;
+            // 
+            // lblGuitarWhammy
+            // 
+            this.lblGuitarWhammy.AutoSize = true;
+            this.lblGuitarWhammy.Location = new System.Drawing.Point(92, 140);
+            this.lblGuitarWhammy.Name = "lblGuitarWhammy";
+            this.lblGuitarWhammy.Size = new System.Drawing.Size(51, 13);
+            this.lblGuitarWhammy.TabIndex = 24;
+            this.lblGuitarWhammy.Text = "Whammy";
+            // 
+            // groupBox7
+            // 
+            this.groupBox7.Controls.Add(this.clbTouchbar);
+            this.groupBox7.Controls.Add(this.lblGuitarType);
+            this.groupBox7.Controls.Add(this.lblGuitarWhammy);
+            this.groupBox7.Controls.Add(this.lblGuitarJoy);
+            this.groupBox7.Controls.Add(this.clbGuitarButtons);
+            this.groupBox7.Location = new System.Drawing.Point(364, 272);
+            this.groupBox7.Name = "groupBox7";
+            this.groupBox7.Size = new System.Drawing.Size(188, 176);
+            this.groupBox7.TabIndex = 36;
+            this.groupBox7.TabStop = false;
+            this.groupBox7.Text = "Guitar";
+            // 
+            // clbTouchbar
+            // 
+            this.clbTouchbar.FormattingEnabled = true;
+            this.clbTouchbar.Items.AddRange(new object[] {
             "Green",
             "Red",
             "Yellow",
             "Blue",
             "Orange"});
-			this.clbTouchbar.Location = new System.Drawing.Point(88, 16);
-			this.clbTouchbar.Name = "clbTouchbar";
-			this.clbTouchbar.Size = new System.Drawing.Size(80, 79);
-			this.clbTouchbar.TabIndex = 25;
-			// 
-			// lblGuitarType
-			// 
-			this.lblGuitarType.AutoSize = true;
-			this.lblGuitarType.Location = new System.Drawing.Point(4, 156);
-			this.lblGuitarType.Name = "lblGuitarType";
-			this.lblGuitarType.Size = new System.Drawing.Size(31, 13);
-			this.lblGuitarType.TabIndex = 24;
-			this.lblGuitarType.Text = "Type";
-			// 
-			// lblGuitarJoy
-			// 
-			this.lblGuitarJoy.Location = new System.Drawing.Point(92, 104);
-			this.lblGuitarJoy.Name = "lblGuitarJoy";
-			this.lblGuitarJoy.Size = new System.Drawing.Size(92, 32);
-			this.lblGuitarJoy.TabIndex = 24;
-			this.lblGuitarJoy.Text = "Joystick Values";
-			// 
-			// clbGuitarButtons
-			// 
-			this.clbGuitarButtons.FormattingEnabled = true;
-			this.clbGuitarButtons.Items.AddRange(new object[] {
+            this.clbTouchbar.Location = new System.Drawing.Point(88, 16);
+            this.clbTouchbar.Name = "clbTouchbar";
+            this.clbTouchbar.Size = new System.Drawing.Size(80, 79);
+            this.clbTouchbar.TabIndex = 25;
+            // 
+            // lblGuitarType
+            // 
+            this.lblGuitarType.AutoSize = true;
+            this.lblGuitarType.Location = new System.Drawing.Point(4, 156);
+            this.lblGuitarType.Name = "lblGuitarType";
+            this.lblGuitarType.Size = new System.Drawing.Size(31, 13);
+            this.lblGuitarType.TabIndex = 24;
+            this.lblGuitarType.Text = "Type";
+            // 
+            // lblGuitarJoy
+            // 
+            this.lblGuitarJoy.Location = new System.Drawing.Point(92, 104);
+            this.lblGuitarJoy.Name = "lblGuitarJoy";
+            this.lblGuitarJoy.Size = new System.Drawing.Size(92, 32);
+            this.lblGuitarJoy.TabIndex = 24;
+            this.lblGuitarJoy.Text = "Joystick Values";
+            // 
+            // clbGuitarButtons
+            // 
+            this.clbGuitarButtons.FormattingEnabled = true;
+            this.clbGuitarButtons.Items.AddRange(new object[] {
             "Green",
             "Red",
             "Yellow",
@@ -371,29 +372,29 @@
             "+",
             "StrumUp",
             "StrumDown"});
-			this.clbGuitarButtons.Location = new System.Drawing.Point(4, 16);
-			this.clbGuitarButtons.Name = "clbGuitarButtons";
-			this.clbGuitarButtons.Size = new System.Drawing.Size(80, 139);
-			this.clbGuitarButtons.TabIndex = 23;
-			// 
-			// groupBox6
-			// 
-			this.groupBox6.Controls.Add(this.lblTriggerR);
-			this.groupBox6.Controls.Add(this.lblTriggerL);
-			this.groupBox6.Controls.Add(this.lblCCJoy2);
-			this.groupBox6.Controls.Add(this.lblCCJoy1);
-			this.groupBox6.Controls.Add(this.clbCCButtons);
-			this.groupBox6.Location = new System.Drawing.Point(364, 0);
-			this.groupBox6.Name = "groupBox6";
-			this.groupBox6.Size = new System.Drawing.Size(188, 268);
-			this.groupBox6.TabIndex = 35;
-			this.groupBox6.TabStop = false;
-			this.groupBox6.Text = "Classic Controller";
-			// 
-			// clbCCButtons
-			// 
-			this.clbCCButtons.FormattingEnabled = true;
-			this.clbCCButtons.Items.AddRange(new object[] {
+            this.clbGuitarButtons.Location = new System.Drawing.Point(4, 16);
+            this.clbGuitarButtons.Name = "clbGuitarButtons";
+            this.clbGuitarButtons.Size = new System.Drawing.Size(80, 139);
+            this.clbGuitarButtons.TabIndex = 23;
+            // 
+            // groupBox6
+            // 
+            this.groupBox6.Controls.Add(this.lblTriggerR);
+            this.groupBox6.Controls.Add(this.lblTriggerL);
+            this.groupBox6.Controls.Add(this.lblCCJoy2);
+            this.groupBox6.Controls.Add(this.lblCCJoy1);
+            this.groupBox6.Controls.Add(this.clbCCButtons);
+            this.groupBox6.Location = new System.Drawing.Point(364, 0);
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.Size = new System.Drawing.Size(188, 268);
+            this.groupBox6.TabIndex = 35;
+            this.groupBox6.TabStop = false;
+            this.groupBox6.Text = "Classic Controller";
+            // 
+            // clbCCButtons
+            // 
+            this.clbCCButtons.FormattingEnabled = true;
+            this.clbCCButtons.Items.AddRange(new object[] {
             "A",
             "B",
             "X",
@@ -409,307 +410,318 @@
             "ZR",
             "LTrigger",
             "RTrigger"});
-			this.clbCCButtons.Location = new System.Drawing.Point(4, 16);
-			this.clbCCButtons.Name = "clbCCButtons";
-			this.clbCCButtons.Size = new System.Drawing.Size(68, 244);
-			this.clbCCButtons.TabIndex = 23;
-			// 
-			// groupBox4
-			// 
-			this.groupBox4.Controls.Add(this.pbBattery);
-			this.groupBox4.Controls.Add(this.lblBattery);
-			this.groupBox4.Location = new System.Drawing.Point(184, 188);
-			this.groupBox4.Name = "groupBox4";
-			this.groupBox4.Size = new System.Drawing.Size(176, 52);
-			this.groupBox4.TabIndex = 33;
-			this.groupBox4.TabStop = false;
-			this.groupBox4.Text = "Battery";
-			// 
-			// pbBattery
-			// 
-			this.pbBattery.Location = new System.Drawing.Point(8, 20);
-			this.pbBattery.Maximum = 200;
-			this.pbBattery.Name = "pbBattery";
-			this.pbBattery.Size = new System.Drawing.Size(128, 23);
-			this.pbBattery.Step = 1;
-			this.pbBattery.TabIndex = 6;
-			// 
-			// lblBattery
-			// 
-			this.lblBattery.AutoSize = true;
-			this.lblBattery.Location = new System.Drawing.Point(140, 24);
-			this.lblBattery.Name = "lblBattery";
-			this.lblBattery.Size = new System.Drawing.Size(35, 13);
-			this.lblBattery.TabIndex = 9;
-			this.lblBattery.Text = "label1";
-			// 
-			// groupBox3
-			// 
-			this.groupBox3.Controls.Add(this.chkLED2);
-			this.groupBox3.Controls.Add(this.chkLED4);
-			this.groupBox3.Controls.Add(this.chkLED3);
-			this.groupBox3.Controls.Add(this.chkLED1);
-			this.groupBox3.Controls.Add(this.chkRumble);
-			this.groupBox3.Location = new System.Drawing.Point(264, 248);
-			this.groupBox3.Name = "groupBox3";
-			this.groupBox3.Size = new System.Drawing.Size(96, 120);
-			this.groupBox3.TabIndex = 32;
-			this.groupBox3.TabStop = false;
-			this.groupBox3.Text = "Outputs";
-			// 
-			// chkLED2
-			// 
-			this.chkLED2.AutoSize = true;
-			this.chkLED2.Location = new System.Drawing.Point(8, 36);
-			this.chkLED2.Name = "chkLED2";
-			this.chkLED2.Size = new System.Drawing.Size(53, 17);
-			this.chkLED2.TabIndex = 3;
-			this.chkLED2.Text = "LED2";
-			this.chkLED2.UseVisualStyleBackColor = true;
-			this.chkLED2.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
-			// 
-			// chkLED4
-			// 
-			this.chkLED4.AutoSize = true;
-			this.chkLED4.Location = new System.Drawing.Point(8, 76);
-			this.chkLED4.Name = "chkLED4";
-			this.chkLED4.Size = new System.Drawing.Size(53, 17);
-			this.chkLED4.TabIndex = 3;
-			this.chkLED4.Text = "LED4";
-			this.chkLED4.UseVisualStyleBackColor = true;
-			this.chkLED4.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
-			// 
-			// chkLED3
-			// 
-			this.chkLED3.AutoSize = true;
-			this.chkLED3.Location = new System.Drawing.Point(8, 56);
-			this.chkLED3.Name = "chkLED3";
-			this.chkLED3.Size = new System.Drawing.Size(53, 17);
-			this.chkLED3.TabIndex = 3;
-			this.chkLED3.Text = "LED3";
-			this.chkLED3.UseVisualStyleBackColor = true;
-			this.chkLED3.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
-			// 
-			// chkLED1
-			// 
-			this.chkLED1.AutoSize = true;
-			this.chkLED1.Location = new System.Drawing.Point(8, 16);
-			this.chkLED1.Name = "chkLED1";
-			this.chkLED1.Size = new System.Drawing.Size(53, 17);
-			this.chkLED1.TabIndex = 3;
-			this.chkLED1.Text = "LED1";
-			this.chkLED1.UseVisualStyleBackColor = true;
-			this.chkLED1.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
-			// 
-			// chkRumble
-			// 
-			this.chkRumble.AutoSize = true;
-			this.chkRumble.Location = new System.Drawing.Point(8, 96);
-			this.chkRumble.Name = "chkRumble";
-			this.chkRumble.Size = new System.Drawing.Size(62, 17);
-			this.chkRumble.TabIndex = 4;
-			this.chkRumble.Text = "Rumble";
-			this.chkRumble.UseVisualStyleBackColor = true;
-			this.chkRumble.CheckedChanged += new System.EventHandler(this.chkRumble_CheckedChanged);
-			// 
-			// chkZ
-			// 
-			this.chkZ.AutoSize = true;
-			this.chkZ.Location = new System.Drawing.Point(8, 112);
-			this.chkZ.Name = "chkZ";
-			this.chkZ.Size = new System.Drawing.Size(33, 17);
-			this.chkZ.TabIndex = 17;
-			this.chkZ.Text = "Z";
-			this.chkZ.UseVisualStyleBackColor = true;
-			// 
-			// chkC
-			// 
-			this.chkC.AutoSize = true;
-			this.chkC.Location = new System.Drawing.Point(8, 92);
-			this.chkC.Name = "chkC";
-			this.chkC.Size = new System.Drawing.Size(33, 17);
-			this.chkC.TabIndex = 17;
-			this.chkC.Text = "C";
-			this.chkC.UseVisualStyleBackColor = true;
-			// 
-			// lblChuk
-			// 
-			this.lblChuk.Location = new System.Drawing.Point(8, 20);
-			this.lblChuk.Name = "lblChuk";
-			this.lblChuk.Size = new System.Drawing.Size(92, 40);
-			this.lblChuk.TabIndex = 13;
-			this.lblChuk.Text = "Accel Values";
-			// 
-			// groupBox2
-			// 
-			this.groupBox2.Controls.Add(this.chkZ);
-			this.groupBox2.Controls.Add(this.chkC);
-			this.groupBox2.Controls.Add(this.lblChuk);
-			this.groupBox2.Controls.Add(this.lblChukJoy);
-			this.groupBox2.Location = new System.Drawing.Point(76, 76);
-			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(104, 136);
-			this.groupBox2.TabIndex = 31;
-			this.groupBox2.TabStop = false;
-			this.groupBox2.Text = "Nunchuk";
-			// 
-			// lblChukJoy
-			// 
-			this.lblChukJoy.Location = new System.Drawing.Point(8, 64);
-			this.lblChukJoy.Name = "lblChukJoy";
-			this.lblChukJoy.Size = new System.Drawing.Size(92, 28);
-			this.lblChukJoy.TabIndex = 16;
-			this.lblChukJoy.Text = "Joystick Values";
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.lblAccel);
-			this.groupBox1.Location = new System.Drawing.Point(76, 0);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(104, 72);
-			this.groupBox1.TabIndex = 30;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "Wiimote Accel";
-			// 
-			// lblAccel
-			// 
-			this.lblAccel.Location = new System.Drawing.Point(8, 20);
-			this.lblAccel.Name = "lblAccel";
-			this.lblAccel.Size = new System.Drawing.Size(88, 48);
-			this.lblAccel.TabIndex = 2;
-			this.lblAccel.Text = "Accel Values";
-			// 
-			// chkExtension
-			// 
-			this.chkExtension.AutoSize = true;
-			this.chkExtension.Location = new System.Drawing.Point(4, 224);
-			this.chkExtension.Name = "chkExtension";
-			this.chkExtension.Size = new System.Drawing.Size(52, 17);
-			this.chkExtension.TabIndex = 29;
-			this.chkExtension.Text = "None";
-			this.chkExtension.UseVisualStyleBackColor = true;
-			// 
-			// groupBox9
-			// 
-			this.groupBox9.Controls.Add(this.lblCOG);
-			this.groupBox9.Controls.Add(this.chkLbs);
-			this.groupBox9.Controls.Add(this.lblBBBR);
-			this.groupBox9.Controls.Add(this.lblBBTR);
-			this.groupBox9.Controls.Add(this.lblBBBL);
-			this.groupBox9.Controls.Add(this.lblBBTotal);
-			this.groupBox9.Controls.Add(this.lblBBTL);
-			this.groupBox9.Location = new System.Drawing.Point(556, 0);
-			this.groupBox9.Name = "groupBox9";
-			this.groupBox9.Size = new System.Drawing.Size(136, 112);
-			this.groupBox9.TabIndex = 38;
-			this.groupBox9.TabStop = false;
-			this.groupBox9.Text = "Balance Board";
-			// 
-			// lblCOG
-			// 
-			this.lblCOG.AutoSize = true;
-			this.lblCOG.Location = new System.Drawing.Point(8, 92);
-			this.lblCOG.Name = "lblCOG";
-			this.lblCOG.Size = new System.Drawing.Size(30, 13);
-			this.lblCOG.TabIndex = 2;
-			this.lblCOG.Text = "COG";
-			// 
-			// chkLbs
-			// 
-			this.chkLbs.AutoSize = true;
-			this.chkLbs.Location = new System.Drawing.Point(28, 68);
-			this.chkLbs.Name = "chkLbs";
-			this.chkLbs.Size = new System.Drawing.Size(62, 17);
-			this.chkLbs.TabIndex = 1;
-			this.chkLbs.Text = "Pounds";
-			this.chkLbs.UseVisualStyleBackColor = true;
-			// 
-			// lblBBBR
-			// 
-			this.lblBBBR.AutoSize = true;
-			this.lblBBBR.Location = new System.Drawing.Point(76, 48);
-			this.lblBBBR.Name = "lblBBBR";
-			this.lblBBBR.Size = new System.Drawing.Size(22, 13);
-			this.lblBBBR.TabIndex = 0;
-			this.lblBBBR.Text = "BR";
-			// 
-			// lblBBTR
-			// 
-			this.lblBBTR.AutoSize = true;
-			this.lblBBTR.Location = new System.Drawing.Point(76, 16);
-			this.lblBBTR.Name = "lblBBTR";
-			this.lblBBTR.Size = new System.Drawing.Size(22, 13);
-			this.lblBBTR.TabIndex = 0;
-			this.lblBBTR.Text = "TR";
-			// 
-			// lblBBBL
-			// 
-			this.lblBBBL.AutoSize = true;
-			this.lblBBBL.Location = new System.Drawing.Point(8, 48);
-			this.lblBBBL.Name = "lblBBBL";
-			this.lblBBBL.Size = new System.Drawing.Size(20, 13);
-			this.lblBBBL.TabIndex = 0;
-			this.lblBBBL.Text = "BL";
-			// 
-			// lblBBTotal
-			// 
-			this.lblBBTotal.AutoSize = true;
-			this.lblBBTotal.Location = new System.Drawing.Point(36, 32);
-			this.lblBBTotal.Name = "lblBBTotal";
-			this.lblBBTotal.Size = new System.Drawing.Size(31, 13);
-			this.lblBBTotal.TabIndex = 0;
-			this.lblBBTotal.Text = "Total";
-			// 
-			// lblBBTL
-			// 
-			this.lblBBTL.AutoSize = true;
-			this.lblBBTL.Location = new System.Drawing.Point(8, 16);
-			this.lblBBTL.Name = "lblBBTL";
-			this.lblBBTL.Size = new System.Drawing.Size(20, 13);
-			this.lblBBTL.TabIndex = 0;
-			this.lblBBTL.Text = "TL";
-			// 
-			// lblDevicePath
-			// 
-			this.lblDevicePath.AutoSize = true;
-			this.lblDevicePath.Location = new System.Drawing.Point(8, 444);
-			this.lblDevicePath.Name = "lblDevicePath";
-			this.lblDevicePath.Size = new System.Drawing.Size(63, 13);
-			this.lblDevicePath.TabIndex = 39;
-			this.lblDevicePath.Text = "DevicePath";
-			// 
-			// groupBox10
-			// 
-			this.groupBox10.Controls.Add(this.lbDrumVelocity);
-			this.groupBox10.Controls.Add(this.lblDrumJoy);
-			this.groupBox10.Controls.Add(this.clbDrums);
-			this.groupBox10.Location = new System.Drawing.Point(556, 112);
-			this.groupBox10.Name = "groupBox10";
-			this.groupBox10.Size = new System.Drawing.Size(136, 180);
-			this.groupBox10.TabIndex = 40;
-			this.groupBox10.TabStop = false;
-			this.groupBox10.Text = "Drums";
-			// 
-			// lbDrumVelocity
-			// 
-			this.lbDrumVelocity.FormattingEnabled = true;
-			this.lbDrumVelocity.Location = new System.Drawing.Point(68, 16);
-			this.lbDrumVelocity.Name = "lbDrumVelocity";
-			this.lbDrumVelocity.Size = new System.Drawing.Size(56, 121);
-			this.lbDrumVelocity.TabIndex = 41;
-			// 
-			// lblDrumJoy
-			// 
-			this.lblDrumJoy.Location = new System.Drawing.Point(8, 144);
-			this.lblDrumJoy.Name = "lblDrumJoy";
-			this.lblDrumJoy.Size = new System.Drawing.Size(92, 32);
-			this.lblDrumJoy.TabIndex = 27;
-			this.lblDrumJoy.Text = "Joystick Values";
-			// 
-			// clbDrums
-			// 
-			this.clbDrums.FormattingEnabled = true;
-			this.clbDrums.Items.AddRange(new object[] {
+            this.clbCCButtons.Location = new System.Drawing.Point(4, 16);
+            this.clbCCButtons.Name = "clbCCButtons";
+            this.clbCCButtons.Size = new System.Drawing.Size(68, 244);
+            this.clbCCButtons.TabIndex = 23;
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.pbBattery);
+            this.groupBox4.Controls.Add(this.lblBattery);
+            this.groupBox4.Location = new System.Drawing.Point(184, 188);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(176, 52);
+            this.groupBox4.TabIndex = 33;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Battery";
+            // 
+            // pbBattery
+            // 
+            this.pbBattery.Location = new System.Drawing.Point(8, 20);
+            this.pbBattery.Maximum = 200;
+            this.pbBattery.Name = "pbBattery";
+            this.pbBattery.Size = new System.Drawing.Size(128, 23);
+            this.pbBattery.Step = 1;
+            this.pbBattery.TabIndex = 6;
+            // 
+            // lblBattery
+            // 
+            this.lblBattery.AutoSize = true;
+            this.lblBattery.Location = new System.Drawing.Point(140, 24);
+            this.lblBattery.Name = "lblBattery";
+            this.lblBattery.Size = new System.Drawing.Size(35, 13);
+            this.lblBattery.TabIndex = 9;
+            this.lblBattery.Text = "label1";
+            // 
+            // groupBox3
+            // 
+            this.groupBox3.Controls.Add(this.chkLED2);
+            this.groupBox3.Controls.Add(this.chkLED4);
+            this.groupBox3.Controls.Add(this.chkLED3);
+            this.groupBox3.Controls.Add(this.chkLED1);
+            this.groupBox3.Controls.Add(this.chkRumble);
+            this.groupBox3.Location = new System.Drawing.Point(264, 248);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Size = new System.Drawing.Size(96, 120);
+            this.groupBox3.TabIndex = 32;
+            this.groupBox3.TabStop = false;
+            this.groupBox3.Text = "Outputs";
+            // 
+            // chkLED2
+            // 
+            this.chkLED2.AutoSize = true;
+            this.chkLED2.Location = new System.Drawing.Point(8, 36);
+            this.chkLED2.Name = "chkLED2";
+            this.chkLED2.Size = new System.Drawing.Size(53, 17);
+            this.chkLED2.TabIndex = 3;
+            this.chkLED2.Text = "LED2";
+            this.chkLED2.UseVisualStyleBackColor = true;
+            this.chkLED2.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
+            // 
+            // chkLED4
+            // 
+            this.chkLED4.AutoSize = true;
+            this.chkLED4.Location = new System.Drawing.Point(8, 76);
+            this.chkLED4.Name = "chkLED4";
+            this.chkLED4.Size = new System.Drawing.Size(53, 17);
+            this.chkLED4.TabIndex = 3;
+            this.chkLED4.Text = "LED4";
+            this.chkLED4.UseVisualStyleBackColor = true;
+            this.chkLED4.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
+            // 
+            // chkLED3
+            // 
+            this.chkLED3.AutoSize = true;
+            this.chkLED3.Location = new System.Drawing.Point(8, 56);
+            this.chkLED3.Name = "chkLED3";
+            this.chkLED3.Size = new System.Drawing.Size(53, 17);
+            this.chkLED3.TabIndex = 3;
+            this.chkLED3.Text = "LED3";
+            this.chkLED3.UseVisualStyleBackColor = true;
+            this.chkLED3.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
+            // 
+            // chkLED1
+            // 
+            this.chkLED1.AutoSize = true;
+            this.chkLED1.Location = new System.Drawing.Point(8, 16);
+            this.chkLED1.Name = "chkLED1";
+            this.chkLED1.Size = new System.Drawing.Size(53, 17);
+            this.chkLED1.TabIndex = 3;
+            this.chkLED1.Text = "LED1";
+            this.chkLED1.UseVisualStyleBackColor = true;
+            this.chkLED1.CheckedChanged += new System.EventHandler(this.chkLED_CheckedChanged);
+            // 
+            // chkRumble
+            // 
+            this.chkRumble.AutoSize = true;
+            this.chkRumble.Location = new System.Drawing.Point(8, 96);
+            this.chkRumble.Name = "chkRumble";
+            this.chkRumble.Size = new System.Drawing.Size(62, 17);
+            this.chkRumble.TabIndex = 4;
+            this.chkRumble.Text = "Rumble";
+            this.chkRumble.UseVisualStyleBackColor = true;
+            this.chkRumble.CheckedChanged += new System.EventHandler(this.chkRumble_CheckedChanged);
+            // 
+            // chkZ
+            // 
+            this.chkZ.AutoSize = true;
+            this.chkZ.Location = new System.Drawing.Point(8, 112);
+            this.chkZ.Name = "chkZ";
+            this.chkZ.Size = new System.Drawing.Size(33, 17);
+            this.chkZ.TabIndex = 17;
+            this.chkZ.Text = "Z";
+            this.chkZ.UseVisualStyleBackColor = true;
+            // 
+            // chkC
+            // 
+            this.chkC.AutoSize = true;
+            this.chkC.Location = new System.Drawing.Point(8, 92);
+            this.chkC.Name = "chkC";
+            this.chkC.Size = new System.Drawing.Size(33, 17);
+            this.chkC.TabIndex = 17;
+            this.chkC.Text = "C";
+            this.chkC.UseVisualStyleBackColor = true;
+            // 
+            // lblChuk
+            // 
+            this.lblChuk.Location = new System.Drawing.Point(8, 20);
+            this.lblChuk.Name = "lblChuk";
+            this.lblChuk.Size = new System.Drawing.Size(92, 40);
+            this.lblChuk.TabIndex = 13;
+            this.lblChuk.Text = "Accel Values";
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.chkZ);
+            this.groupBox2.Controls.Add(this.chkC);
+            this.groupBox2.Controls.Add(this.lblChuk);
+            this.groupBox2.Controls.Add(this.lblChukJoy);
+            this.groupBox2.Location = new System.Drawing.Point(76, 76);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(104, 136);
+            this.groupBox2.TabIndex = 31;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Nunchuk";
+            // 
+            // lblChukJoy
+            // 
+            this.lblChukJoy.Location = new System.Drawing.Point(8, 64);
+            this.lblChukJoy.Name = "lblChukJoy";
+            this.lblChukJoy.Size = new System.Drawing.Size(92, 28);
+            this.lblChukJoy.TabIndex = 16;
+            this.lblChukJoy.Text = "Joystick Values";
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.lblAccel);
+            this.groupBox1.Location = new System.Drawing.Point(76, 0);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(104, 72);
+            this.groupBox1.TabIndex = 30;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Wiimote Accel";
+            // 
+            // lblAccel
+            // 
+            this.lblAccel.Location = new System.Drawing.Point(8, 20);
+            this.lblAccel.Name = "lblAccel";
+            this.lblAccel.Size = new System.Drawing.Size(88, 48);
+            this.lblAccel.TabIndex = 2;
+            this.lblAccel.Text = "Accel Values";
+            // 
+            // chkExtension
+            // 
+            this.chkExtension.AutoSize = true;
+            this.chkExtension.Location = new System.Drawing.Point(4, 224);
+            this.chkExtension.Name = "chkExtension";
+            this.chkExtension.Size = new System.Drawing.Size(52, 17);
+            this.chkExtension.TabIndex = 29;
+            this.chkExtension.Text = "None";
+            this.chkExtension.UseVisualStyleBackColor = true;
+            // 
+            // groupBox9
+            // 
+            this.groupBox9.Controls.Add(this.SetZeroPoint);
+            this.groupBox9.Controls.Add(this.lblCOG);
+            this.groupBox9.Controls.Add(this.chkLbs);
+            this.groupBox9.Controls.Add(this.lblBBBR);
+            this.groupBox9.Controls.Add(this.lblBBTR);
+            this.groupBox9.Controls.Add(this.lblBBBL);
+            this.groupBox9.Controls.Add(this.lblBBTotal);
+            this.groupBox9.Controls.Add(this.lblBBTL);
+            this.groupBox9.Location = new System.Drawing.Point(556, 0);
+            this.groupBox9.Name = "groupBox9";
+            this.groupBox9.Size = new System.Drawing.Size(136, 155);
+            this.groupBox9.TabIndex = 38;
+            this.groupBox9.TabStop = false;
+            this.groupBox9.Text = "Balance Board";
+            // 
+            // SetZeroPoint
+            // 
+            this.SetZeroPoint.Location = new System.Drawing.Point(11, 118);
+            this.SetZeroPoint.Name = "SetZeroPoint";
+            this.SetZeroPoint.Size = new System.Drawing.Size(75, 23);
+            this.SetZeroPoint.TabIndex = 3;
+            this.SetZeroPoint.Text = "Zero Weight";
+            this.SetZeroPoint.UseVisualStyleBackColor = true;
+            this.SetZeroPoint.Click += new System.EventHandler(this.CalZeroPoint_Click);
+            // 
+            // lblCOG
+            // 
+            this.lblCOG.AutoSize = true;
+            this.lblCOG.Location = new System.Drawing.Point(8, 92);
+            this.lblCOG.Name = "lblCOG";
+            this.lblCOG.Size = new System.Drawing.Size(30, 13);
+            this.lblCOG.TabIndex = 2;
+            this.lblCOG.Text = "COG";
+            // 
+            // chkLbs
+            // 
+            this.chkLbs.AutoSize = true;
+            this.chkLbs.Location = new System.Drawing.Point(28, 68);
+            this.chkLbs.Name = "chkLbs";
+            this.chkLbs.Size = new System.Drawing.Size(62, 17);
+            this.chkLbs.TabIndex = 1;
+            this.chkLbs.Text = "Pounds";
+            this.chkLbs.UseVisualStyleBackColor = true;
+            // 
+            // lblBBBR
+            // 
+            this.lblBBBR.AutoSize = true;
+            this.lblBBBR.Location = new System.Drawing.Point(76, 48);
+            this.lblBBBR.Name = "lblBBBR";
+            this.lblBBBR.Size = new System.Drawing.Size(22, 13);
+            this.lblBBBR.TabIndex = 0;
+            this.lblBBBR.Text = "BR";
+            // 
+            // lblBBTR
+            // 
+            this.lblBBTR.AutoSize = true;
+            this.lblBBTR.Location = new System.Drawing.Point(76, 16);
+            this.lblBBTR.Name = "lblBBTR";
+            this.lblBBTR.Size = new System.Drawing.Size(22, 13);
+            this.lblBBTR.TabIndex = 0;
+            this.lblBBTR.Text = "TR";
+            // 
+            // lblBBBL
+            // 
+            this.lblBBBL.AutoSize = true;
+            this.lblBBBL.Location = new System.Drawing.Point(8, 48);
+            this.lblBBBL.Name = "lblBBBL";
+            this.lblBBBL.Size = new System.Drawing.Size(20, 13);
+            this.lblBBBL.TabIndex = 0;
+            this.lblBBBL.Text = "BL";
+            // 
+            // lblBBTotal
+            // 
+            this.lblBBTotal.AutoSize = true;
+            this.lblBBTotal.Location = new System.Drawing.Point(36, 32);
+            this.lblBBTotal.Name = "lblBBTotal";
+            this.lblBBTotal.Size = new System.Drawing.Size(31, 13);
+            this.lblBBTotal.TabIndex = 0;
+            this.lblBBTotal.Text = "Total";
+            // 
+            // lblBBTL
+            // 
+            this.lblBBTL.AutoSize = true;
+            this.lblBBTL.Location = new System.Drawing.Point(8, 16);
+            this.lblBBTL.Name = "lblBBTL";
+            this.lblBBTL.Size = new System.Drawing.Size(20, 13);
+            this.lblBBTL.TabIndex = 0;
+            this.lblBBTL.Text = "TL";
+            // 
+            // lblDevicePath
+            // 
+            this.lblDevicePath.AutoSize = true;
+            this.lblDevicePath.Location = new System.Drawing.Point(8, 444);
+            this.lblDevicePath.Name = "lblDevicePath";
+            this.lblDevicePath.Size = new System.Drawing.Size(63, 13);
+            this.lblDevicePath.TabIndex = 39;
+            this.lblDevicePath.Text = "DevicePath";
+            // 
+            // groupBox10
+            // 
+            this.groupBox10.Controls.Add(this.lbDrumVelocity);
+            this.groupBox10.Controls.Add(this.lblDrumJoy);
+            this.groupBox10.Controls.Add(this.clbDrums);
+            this.groupBox10.Location = new System.Drawing.Point(556, 161);
+            this.groupBox10.Name = "groupBox10";
+            this.groupBox10.Size = new System.Drawing.Size(136, 180);
+            this.groupBox10.TabIndex = 40;
+            this.groupBox10.TabStop = false;
+            this.groupBox10.Text = "Drums";
+            // 
+            // lbDrumVelocity
+            // 
+            this.lbDrumVelocity.FormattingEnabled = true;
+            this.lbDrumVelocity.Location = new System.Drawing.Point(68, 16);
+            this.lbDrumVelocity.Name = "lbDrumVelocity";
+            this.lbDrumVelocity.Size = new System.Drawing.Size(56, 121);
+            this.lbDrumVelocity.TabIndex = 41;
+            // 
+            // lblDrumJoy
+            // 
+            this.lblDrumJoy.Location = new System.Drawing.Point(8, 144);
+            this.lblDrumJoy.Name = "lblDrumJoy";
+            this.lblDrumJoy.Size = new System.Drawing.Size(92, 32);
+            this.lblDrumJoy.TabIndex = 27;
+            this.lblDrumJoy.Text = "Joystick Values";
+            // 
+            // clbDrums
+            // 
+            this.clbDrums.FormattingEnabled = true;
+            this.clbDrums.Items.AddRange(new object[] {
             "Red",
             "Blue",
             "Green",
@@ -718,50 +730,50 @@
             "Pedal",
             "-",
             "+"});
-			this.clbDrums.Location = new System.Drawing.Point(4, 16);
-			this.clbDrums.Name = "clbDrums";
-			this.clbDrums.Size = new System.Drawing.Size(60, 124);
-			this.clbDrums.TabIndex = 26;
-			// 
-			// WiimoteInfo
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.groupBox10);
-			this.Controls.Add(this.lblDevicePath);
-			this.Controls.Add(this.groupBox9);
-			this.Controls.Add(this.groupBox8);
-			this.Controls.Add(this.groupBox5);
-			this.Controls.Add(this.pbIR);
-			this.Controls.Add(this.groupBox7);
-			this.Controls.Add(this.groupBox6);
-			this.Controls.Add(this.groupBox4);
-			this.Controls.Add(this.groupBox3);
-			this.Controls.Add(this.groupBox2);
-			this.Controls.Add(this.groupBox1);
-			this.Controls.Add(this.chkExtension);
-			this.Name = "WiimoteInfo";
-			this.Size = new System.Drawing.Size(696, 464);
-			this.groupBox8.ResumeLayout(false);
-			this.groupBox5.ResumeLayout(false);
-			this.groupBox5.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pbIR)).EndInit();
-			this.groupBox7.ResumeLayout(false);
-			this.groupBox7.PerformLayout();
-			this.groupBox6.ResumeLayout(false);
-			this.groupBox6.PerformLayout();
-			this.groupBox4.ResumeLayout(false);
-			this.groupBox4.PerformLayout();
-			this.groupBox3.ResumeLayout(false);
-			this.groupBox3.PerformLayout();
-			this.groupBox2.ResumeLayout(false);
-			this.groupBox2.PerformLayout();
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox9.ResumeLayout(false);
-			this.groupBox9.PerformLayout();
-			this.groupBox10.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.clbDrums.Location = new System.Drawing.Point(4, 16);
+            this.clbDrums.Name = "clbDrums";
+            this.clbDrums.Size = new System.Drawing.Size(60, 124);
+            this.clbDrums.TabIndex = 26;
+            // 
+            // WiimoteInfo
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupBox10);
+            this.Controls.Add(this.lblDevicePath);
+            this.Controls.Add(this.groupBox9);
+            this.Controls.Add(this.groupBox8);
+            this.Controls.Add(this.groupBox5);
+            this.Controls.Add(this.pbIR);
+            this.Controls.Add(this.groupBox7);
+            this.Controls.Add(this.groupBox6);
+            this.Controls.Add(this.groupBox4);
+            this.Controls.Add(this.groupBox3);
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.chkExtension);
+            this.Name = "WiimoteInfo";
+            this.Size = new System.Drawing.Size(696, 464);
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pbIR)).EndInit();
+            this.groupBox7.ResumeLayout(false);
+            this.groupBox7.PerformLayout();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
+            this.groupBox3.ResumeLayout(false);
+            this.groupBox3.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox9.ResumeLayout(false);
+            this.groupBox9.PerformLayout();
+            this.groupBox10.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -825,6 +837,6 @@
 		public System.Windows.Forms.CheckedListBox clbDrums;
 		public System.Windows.Forms.Label lblDrumJoy;
 		private System.Windows.Forms.ListBox lbDrumVelocity;
-
-	}
+        private System.Windows.Forms.Button SetZeroPoint;
+    }
 }

--- a/WiimoteCS/WiimoteTest/WiimoteInfo.cs
+++ b/WiimoteCS/WiimoteTest/WiimoteInfo.cs
@@ -216,5 +216,10 @@ namespace WiimoteTest
 		{
 			set { mWiimote = value; }
 		}
-	}
+
+        private void CalZeroPoint_Click(object sender, EventArgs e)
+        {
+			mWiimote.WiimoteState.BalanceBoardState.ZeroPoint.Reset = true;
+		}
+    }
 }

--- a/WiimoteVB/WiimoteLib/Wiimote.vb
+++ b/WiimoteVB/WiimoteLib/Wiimote.vb
@@ -785,8 +785,8 @@ Namespace WiimoteLib
 					mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft = (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft * KG2LB)
 					mWiimoteState.BalanceBoardState.SensorValuesLb.BottomRight = (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight * KG2LB)
 
-					mWiimoteState.BalanceBoardState.WeightKg = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight) / 4.0f
-					mWiimoteState.BalanceBoardState.WeightLb = (mWiimoteState.BalanceBoardState.SensorValuesLb.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.TopRight + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomRight) / 4.0f
+					mWiimoteState.BalanceBoardState.WeightKg = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight)
+					mWiimoteState.BalanceBoardState.WeightLb = (mWiimoteState.BalanceBoardState.SensorValuesLb.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.TopRight + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesLb.BottomRight)
 
 					Dim Kx As Single = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft) / (mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight)
 					Dim Ky As Single = (mWiimoteState.BalanceBoardState.SensorValuesKg.TopLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.TopRight) / (mWiimoteState.BalanceBoardState.SensorValuesKg.BottomLeft + mWiimoteState.BalanceBoardState.SensorValuesKg.BottomRight)
@@ -802,9 +802,9 @@ Namespace WiimoteLib
 			End If
 
 			If sensor < mid Then
-				Return 68.0f * (CSng(sensor - min) / (mid - min))
+				Return 17.0f * (CSng(sensor - min) / (mid - min))
 			Else
-				Return 68.0f * (CSng(sensor - mid) / (max - mid)) + 68.0f
+				Return 17.0f * (CSng(sensor - mid) / (max - mid)) + 17.0f
 			End If
 		End Function
 


### PR DESCRIPTION
Added  a way to calibrate the zero point on the wii balance board. (get off the board, click the 'zero weight' button, and all the weights reset to 0.)
Modification to the wiimote library, and also added a button to the wiimoTest program.

I have implemented this by subtraction based on the user weight in KG ( note the 3 different ways I thought about for implementation, in issue #8 ). I'm still unsure if this is the best way to implement this, but it's definitely better than no calibration at all!